### PR TITLE
docs(changelog): actualizar contenido del changelog [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,55 +1,3 @@
-# [1.0.0-beta.2](https://github.com/lgzarturo/springboot-course/compare/v1.0.0-beta.1...v1.0.0-beta.2) (2025-10-25)
-
-
-### Bug Fixes
-
-* **doc:** update docs/course/week-01/01-dependencias.md ([185a2b0](https://github.com/lgzarturo/springboot-course/commit/185a2b0bd72d4516f5ef6404e8a80f0504d3acf6))
-* **doc:** update docs/course/week-01/01-dependencias.md ([5e7c5f4](https://github.com/lgzarturo/springboot-course/commit/5e7c5f4edabd89bdb708bdfa893d0258ba7e33c4))
-* **validation:** update GlobalExceptionHandler.kt ([0850fc1](https://github.com/lgzarturo/springboot-course/commit/0850fc123027ef58e971af811fb2259c3158046f))
-
-
-### Features
-
-* **build:** configurar para versión automatizada y flujo de commits ([7c4c27a](https://github.com/lgzarturo/springboot-course/commit/7c4c27a4e54556a93deac11e2bb4482eacb8e1a8)), closes [#2](https://github.com/lgzarturo/springboot-course/issues/2)
-* **build:** configurar para versión automatizada y flujo de commits ([6c00404](https://github.com/lgzarturo/springboot-course/commit/6c004042254394990ccb9fc4cc27649326e57ccf)), closes [#2](https://github.com/lgzarturo/springboot-course/issues/2)
-* **ci:** actualizar workflows con permisos refinados. ([3915f6c](https://github.com/lgzarturo/springboot-course/commit/3915f6c156e801dd4a7a8120dc6d3395084ea3ce))
-* **ci:** agregar flujos de trabajo de CI/CD y changelog ([13eb7c3](https://github.com/lgzarturo/springboot-course/commit/13eb7c30fc71d67930f7376dceaf4ad5cedc82be)), closes [#2](https://github.com/lgzarturo/springboot-course/issues/2)
-* **config:** agregar configuración de OpenAPI y manejo de excepciones ([dd0b923](https://github.com/lgzarturo/springboot-course/commit/dd0b92336370c389893dee70b09e11458ecc39bc)), closes [#5](https://github.com/lgzarturo/springboot-course/issues/5) [#6](https://github.com/lgzarturo/springboot-course/issues/6)
-* **docs:** agregar nuevas guías de workflow y commits `.releaserc.json` ([616a0df](https://github.com/lgzarturo/springboot-course/commit/616a0df2a044fbc1f61d3076025b12db1a807086))
-
-# 1.0.0-beta.1 (2025-10-21)
-
-
-### Bug Fixes
-
-* corrige error menor de prueba en la aplicación ([746a40a](https://github.com/lgzarturo/springboot-course/commit/746a40ae400e8f11d501820aa0368adc06ea5744))
-* forzar próximo release a partir de 0.0.1 ([d599c6c](https://github.com/lgzarturo/springboot-course/commit/d599c6ca44f3fb4af44d80915f8a684ae2773ef3))
-
-
-### Features
-
-* agregar flujo de trabajo para publicación de versiones ([2de3737](https://github.com/lgzarturo/springboot-course/commit/2de3737389da78fcc42b9025db3397acf6a5ab49))
-* **build:** agregar dependencias OpenAPI y configuración de Qodana ([20afbd2](https://github.com/lgzarturo/springboot-course/commit/20afbd2df7d0569fd35c1df98b61ec1446488c60))
-* **build:** agregar soporte la observabilidad ([d3cfafc](https://github.com/lgzarturo/springboot-course/commit/d3cfafc9edbdf3feb01c897964072785ec6faea7))
-* **project:** configura inicialización con SpringBoot+Kotlin ([b0e918d](https://github.com/lgzarturo/springboot-course/commit/b0e918d69d98a2bf30c2cc3af6966fc0c57f37e2))
-
-# [1.0.0-beta.2](https://github.com/lgzarturo/springboot-course/compare/v1.0.0-beta.1...v1.0.0-beta.2) (2025-10-21)
-
-
-### Bug Fixes
-
-* corrige error menor de prueba en la aplicación ([746a40a](https://github.com/lgzarturo/springboot-course/commit/746a40ae400e8f11d501820aa0368adc06ea5744))
-
-# 1.0.0-beta.1 (2025-10-21)
-
-
-### Features
-
-* agregar flujo de trabajo para publicación de versiones ([2de3737](https://github.com/lgzarturo/springboot-course/commit/2de3737389da78fcc42b9025db3397acf6a5ab49))
-* **build:** agregar dependencias OpenAPI y configuración de Qodana ([20afbd2](https://github.com/lgzarturo/springboot-course/commit/20afbd2df7d0569fd35c1df98b61ec1446488c60))
-* **build:** agregar soporte la observabilidad ([d3cfafc](https://github.com/lgzarturo/springboot-course/commit/d3cfafc9edbdf3feb01c897964072785ec6faea7))
-* **project:** configura inicialización con SpringBoot+Kotlin ([b0e918d](https://github.com/lgzarturo/springboot-course/commit/b0e918d69d98a2bf30c2cc3af6966fc0c57f37e2))
-
 # Changelog
 
 Todos los cambios notables del proyecto serán documentados aquí.
@@ -57,17 +5,7 @@ Todos los cambios notables del proyecto serán documentados aquí.
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 y este proyecto se basa en [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.0.1] - 2025-10-20
-
-### Added
-- Flujo de trabajo completo para commits con Conventional Commits
-- Documentación de versionado semántico
-- Guías para generación automática de changelog
-- Plantilla de mensajes de commit (.gitmessage)
-- Guía rápida de commits (COMMIT_GUIDE.md)
-- Workflow completo documentado (WORKFLOW.md)
-
-## [0.0.1-SNAPSHOT] - 2025-10-20
+## [0.0.1] - 2025-10-25
 
 ### Added
 - Implementación inicial del proyecto Spring Boot Course
@@ -97,6 +35,27 @@ y este proyecto se basa en [Semantic Versioning](https://semver.org/spec/v2.0.0.
   - Semana 0: Historia del viaje y método de aprendizaje
   - Semana 1: Dependencias
   - Semana 2: HTTP, Spring Boot y componentes clave
+- Flujo de trabajo completo para commits con Conventional Commits
+- Documentación de versionado semántico
+- Guías para generación automática de changelog
+- Plantilla de mensajes de commit (.gitmessage)
+- Guía rápida de commits (COMMIT_GUIDE.md)
+- Workflow completo documentado (WORKFLOW.md)
+- Flujo de trabajo para publicación de versiones
+- Dependencias OpenAPI y configuración de Qodana
+- Soporte para observabilidad
+- Flujos de trabajo de CI/CD y changelog
+- Configuración de OpenAPI y manejo de excepciones global
+- Nuevas guías de workflow y commits con `.releaserc.json`
+
+### Changed
+- Actualización de documentación en docs/course/week-01/01-dependencias.md
+- Actualización de GlobalExceptionHandler.kt para mejorar validaciones
+- Workflows actualizados con permisos refinados
+
+### Fixed
+- Corrección de error menor de prueba en la aplicación
+- Ajustes en la configuración para versión automatizada y flujo de commits
 
 ### Configuration
 - Gradle 8.x con Kotlin DSL
@@ -105,4 +64,4 @@ y este proyecto se basa en [Semantic Versioning](https://semver.org/spec/v2.0.0.
 - CORS configurado
 - Manejo global de excepciones
 
-[Unreleased]: https://github.com/lgzarturo/springboot-course/compare/v0.0.1-SNAPSHOT...HEAD
+[0.0.1]: https://github.com/lgzarturo/springboot-course/releases/tag/v0.0.1


### PR DESCRIPTION
Se consolidaron y reorganizaron las secciones del changelog para homogeneizar el formato y mejorar la claridad. Se unificaron entradas redundantes y se reordenaron cambios según Keep a Changelog.
